### PR TITLE
Added support for checking line lengths - This solves #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Do this before your sprint planning sessions and remember to pay your technical 
 * too-long/file-too-long: file length more than 250 lines
 * todo-comment: TODO comment found in code
 * console-call: found statements like console.log()
-* line-length: code line that is more than 80 characters long
+* line-length: code line that is more than 100 characters long

--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ Do this before your sprint planning sessions and remember to pay your technical 
 * too-long/file-too-long: file length more than 250 lines
 * todo-comment: TODO comment found in code
 * console-call: found statements like console.log()
+* line-length: code line that is more than 80 characters long

--- a/dummy-files/file.js
+++ b/dummy-files/file.js
@@ -12,3 +12,7 @@ function test() {
 function test2(param1, param2, param3, param4, param5) {
   // TODO: Figure out what to do about the dragons
 }
+
+function thisIsAReallyLongFunctionName(that, takes, many, args, and, not, readable) {
+  
+}

--- a/index.js
+++ b/index.js
@@ -13,12 +13,14 @@ const ParamsLength = require('./lib/validators/function-validator');
 const LineCheck = require('./lib/validators/file-length');
 const TodoCheck = require('./lib/validators/comments.js');
 const ConsoleCheck = require('./lib/validators/console');
+const LineLengthCheck = require('./lib/validators/line-length');
 
 // Initiate validators
 const paramsCheckInstance = new ParamsLength();
 const lineCheckInstance = new LineCheck();
 const todoCheckInstance = new TodoCheck();
 const consoleCheckInstance = new ConsoleCheck();
+const lineLengthInstance = new LineLengthCheck();
 
 const report = new Report();
 const walkPath = process.argv[2];
@@ -55,6 +57,7 @@ async function walk(dir) {
         paramsCheckInstance.checkParams(line, file, pathToReport);
         todoCheckInstance.checkForTodoComments(line, file, pathToReport);
         consoleCheckInstance.checkForConsoleCalls(line, file, pathToReport);
+        lineLengthInstance.checkMaxLength(line, file, pathToReport);
       });
 
       rl.on('close', () => {

--- a/lib/validators/line-length.js
+++ b/lib/validators/line-length.js
@@ -4,7 +4,7 @@ const report = new Report();
 
 function lineLengthCheck() {
   this.checkMaxLength = (line, file, pathToReport) => {
-    if (line.length > 80) {
+    if (line.length > 100) {
       report.writeToReport(`- [ ] ${file} has a long code line. Consider refactor. (line-length)`, pathToReport);
     }
   };

--- a/lib/validators/line-length.js
+++ b/lib/validators/line-length.js
@@ -1,0 +1,13 @@
+const Report = require('../file-handling/write-report');
+
+const report = new Report();
+
+function lineLengthCheck() {
+  this.checkMaxLength = (line, file, pathToReport) => {
+    if (line.length > 80) {
+      report.writeToReport(`- [ ] ${file} has a long code line. Consider refactor. (line-length)`, pathToReport);
+    }
+  };
+}
+
+module.exports = lineLengthCheck;

--- a/test/line-length.test.js
+++ b/test/line-length.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const mock = require('mock-fs');
+const mocha = require('mocha');
+const chai = require('chai');
+
+const LineLengthCheck = require('../lib/validators/line-length.js');
+
+const lineLengthInstance = new LineLengthCheck();
+
+mocha.describe('Line Length', () => {
+  mocha.beforeEach(() => {
+    mock({
+      'report.md': '',
+    });
+  });
+
+  mocha.it('should not write to report if it finds a short line', () => {
+    lineLengthInstance.checkMaxLength('const shortVarName = true', 'somefile.js', './report.md');
+    const reportAfterCheck = fs.readFileSync('./report.md').toString();
+    chai.expect(reportAfterCheck).to.be.lengthOf(0);
+    chai.expect(reportAfterCheck).not.to.contain('(line-length)');
+  });
+
+  mocha.it('should not write to report if it finds a 80 character line', () => {
+    lineLengthInstance.checkMaxLength('const someReallyLongVarName = "With some quite long text in it as well........."', 'somefile.js', './report.md');
+    const reportAfterCheck = fs.readFileSync('./report.md').toString();
+    chai.expect(reportAfterCheck).to.be.lengthOf(0);
+    chai.expect(reportAfterCheck).not.to.contain('(line-length)');
+  });
+
+  mocha.it('should write to report if it finds a 81 character line', () => {
+    lineLengthInstance.checkMaxLength('const someReallyLongVarName = "With some quite long text in it as well.........."', 'somefile.js', './report.md');
+    const reportAfterCheck = fs.readFileSync('./report.md').toString();
+    chai.expect(reportAfterCheck).not.to.be.lengthOf(0);
+    chai.expect(reportAfterCheck).to.contain('(line-length)');
+  });
+
+  mocha.after(() => {
+    mock.restore();
+  });
+});

--- a/test/line-length.test.js
+++ b/test/line-length.test.js
@@ -15,21 +15,21 @@ mocha.describe('Line Length', () => {
   });
 
   mocha.it('should not write to report if it finds a short line', () => {
-    lineLengthInstance.checkMaxLength('const shortVarName = true', 'somefile.js', './report.md');
+    lineLengthInstance.checkMaxLength('const shortVarName = true;', 'somefile.js', './report.md');
     const reportAfterCheck = fs.readFileSync('./report.md').toString();
     chai.expect(reportAfterCheck).to.be.lengthOf(0);
     chai.expect(reportAfterCheck).not.to.contain('(line-length)');
   });
 
-  mocha.it('should not write to report if it finds a 80 character line', () => {
-    lineLengthInstance.checkMaxLength('const someReallyLongVarName = "With some quite long text in it as well........."', 'somefile.js', './report.md');
+  mocha.it('should not write to report if it finds a 100 character line', () => {
+    lineLengthInstance.checkMaxLength('const someReallyLongVarName = "With some quite long text in it as well............................."', 'somefile.js', './report.md');
     const reportAfterCheck = fs.readFileSync('./report.md').toString();
     chai.expect(reportAfterCheck).to.be.lengthOf(0);
     chai.expect(reportAfterCheck).not.to.contain('(line-length)');
   });
 
-  mocha.it('should write to report if it finds a 81 character line', () => {
-    lineLengthInstance.checkMaxLength('const someReallyLongVarName = "With some quite long text in it as well.........."', 'somefile.js', './report.md');
+  mocha.it('should write to report if it finds a 101 character line', () => {
+    lineLengthInstance.checkMaxLength('const someReallyLongVarName = "With some quite long text in it as well.............................."', 'somefile.js', './report.md');
     const reportAfterCheck = fs.readFileSync('./report.md').toString();
     chai.expect(reportAfterCheck).not.to.be.lengthOf(0);
     chai.expect(reportAfterCheck).to.contain('(line-length)');


### PR DESCRIPTION
This solves #7 

However..
We should maybe consider the length requirement. 
All best practise posts I can find says that 80 is the limit for Javascript, like here: http://www.codereadability.com/maximum-line-length/

But..
Lannister it self has some problems limiting to that. Especially on our test cases.

Should we have this feature at all, or should we extend the limit to 100 or 120 characters? @kennethlarsen 